### PR TITLE
Added categorical fact distribution with example usage

### DIFF
--- a/use-cases/new_demo_experiments.yml
+++ b/use-cases/new_demo_experiments.yml
@@ -744,6 +744,23 @@ fact_sources:
                   effect: 0.01
           type: bernoulli
         name: is_voided
+      - distribution:
+          parameters:
+            clothing:
+              baseline_value: 0.5
+              conditional_effects:
+                - conditions:
+                    - column: experiment
+                      value: checkout_process
+                    - column: variant
+                      value: simplified
+                  effect: -0.005
+            cooking:
+              baseline_value: 0.3
+            electronics:
+              baseline_value: 0.2
+          type: categorical
+        name: item_type
     frequency_distribution:
       parameters:
         rate:


### PR DESCRIPTION
Added the ability to specify categorical distributions. These can be used either for fact properties or as facts (e.g., for count distinct metrics). I also added example usage to our standard demo config file. Note that you can also specify conditional (and treatment) effects on the relative weighting of each specified category.